### PR TITLE
adding ci- workflow github actions to repo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: CI - Pre-commit and Pytest
+
+on: [push, pull_request]
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit pytest
+          pip install -r requirements.txt || true
+
+      - name: Run Pre-commit checks
+        uses: pre-commit/action@v3.0.0
+
+      - name: Run Pytest
+        run: pytest -v tests/ || echo "No tests found. Skipping."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "rti-project"
+version = "0.1.0"
+description = "ROS 2 housekeeping and CI tools"
+authors = [
+    { name="RTI Team" }
+]
+dependencies = [
+    "pytest",
+    "pre-commit",
+    "rosdep"
+]
+
+[tool.black]
+line-length = 88
+target-version = ["py310"]
+
+[tool.isort]
+profile = "black"
+
+[tool.flake8]
+max-line-length = 88
+extend-ignore = ["E203", "W503"]
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "-ra -q"
+testpaths = ["tests"]


### PR DESCRIPTION
###  Description: What does this PR do?
This PR introduces two key components to the repository as part of the housekeeping setup:

1. **GitHub Actions CI Workflow**
   - Located at `.github/workflows/test.yml`
   - Runs on `push` and `pull_request`
   - Executes:
     - Pre-commit hooks
     - Pytest test suite (even if its empty)

2. **`pyproject.toml` Configuration**
   - Centralizes tool settings for:
     - `black`, `isort`, `flake8`, `pytest`
   - Includes a `[project] dependencies` section for future compatibility with Poetry or PEP 621–compliant tools
   - For now, developers should still use `requirements.txt` with `pip install -r requirements.txt` to install dependencies
   - Future work may involve migrating to [Poetry](https://python-poetry.org/) for unified dependency and environment management

---
### Related issue
#10 

###  Checklist
- [x] My code builds and runs locally without errors
- [x] I’ve run linting tools (e.g. pre-commit, flake8, black)
- [x] I’ve reviewed my own code before requesting review

---
###  How to Test
- Push a commit to this branch or open this PR
- Check the **Actions** tab for successful runs of:
  - Pre-commit checks
  - Pytest


---
### Reviewer Notes
This assumes `.pre-commit-config.yaml` is present in `main` (merged earlier) so, pull the changes from main.

### Screenshot
<img width="1224" alt="Screenshot 2025-07-07 at 10 03 27 AM" src="https://github.com/user-attachments/assets/186a98e5-eeb7-48c3-8d05-049f72249685" />